### PR TITLE
表示時間を日本時間に直す

### DIFF
--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content @message.content
 json.image @message.image.url
 json.user_name @message.user.name
-json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.id @message.id

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module ChatSpace
     end
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
#what
メッセージを投稿した際の時間を日本時間にする。
#why
ユーザーの多くが日本に住んでいることを想定しているため。